### PR TITLE
define legacy redirects chart and configure linting, tests, repo docs

### DIFF
--- a/.github/workflows/lint_chart.yaml
+++ b/.github/workflows/lint_chart.yaml
@@ -1,0 +1,37 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.2
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.9.2
+          version: v3.12.2
 
       # Keeping this comment in here, since it is a hard to remember step that we
       # will need later
@@ -31,7 +31,7 @@ jobs:
       #     helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"

--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -1,0 +1,37 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.9.2
+
+      # Keeping this comment in here, since it is a hard to remember step that we
+      # will need later
+      # - name: Seed helm deps
+      #   run: |
+      #     helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.3.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Chart dependencies
+**/charts/*.tgz

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ helm-docs
 
 ### Testing
 
-For charts that have tests, you need to have the [chart-testing](https://github.com/helm/chart-testing) and [KinD](https://github.com/kubernetes-sigs/kind) tools installed to run them locally.
+For charts that have tests, you need to have the following in order to run the tests:
+  - [chart-testing](https://github.com/helm/chart-testing) and its dependencies:
+    - [Yamllint](https://github.com/adrienverge/yamllint)
+    - [Yamale](https://github.com/23andMe/Yamale)
+  - [KinD](https://github.com/kubernetes-sigs/kind) tools installed to run them locally.
 
 ```bash
 # create a kubernetes-in-docker cluster, and make sure it is your current kubectl context

--- a/README.md
+++ b/README.md
@@ -36,5 +36,6 @@ kind create cluster
 # For private GCR registries, authenticate using an access token, using the kind-gcr.sh script: https://kind.sigs.k8s.io/docs/user/private-registries/#use-an-access-token
 ./kind-gcr.sh
 # run ct from the root of the git repo to test any helm charts that have changed in your current branch, relevant to main
-ct lint-and-install --target-branch main
+ct lint-and-install # for integration test
+ct lint # for just linting
 ```

--- a/README.md
+++ b/README.md
@@ -13,3 +13,28 @@ This repository contains the [Helm](https://helm.sh) Charts for deploying the gn
 - [ingress](./charts/gnomad-ingress)
 	- A chart for managing ingress separately from the browser deployment. This is useful for cases when you want to deploy a single ingress with many services behind it.
 - [gnomAD Legacy Redirects service](./charts/legacy-redirects)
+
+
+## Development
+
+### Generating Documentation
+
+After updating any helm chart values or updating the [README Template](./README.md.gotmpl) for a chart, you should regenerate the documentation using [helm-docs](https://github.com/norwoodj/helm-docs)
+
+```bash
+cd charts/chart-name  # the directory with Chart.yaml in it
+helm-docs
+```
+
+### Testing
+
+For charts that have tests, you need to have the [chart-testing](https://github.com/helm/chart-testing) and [KinD](https://github.com/kubernetes-sigs/kind) tools installed to run them locally.
+
+```bash
+# create a kubernetes-in-docker cluster, and make sure it is your current kubectl context
+kind create cluster
+# For private GCR registries, authenticate using an access token, using the kind-gcr.sh script: https://kind.sigs.k8s.io/docs/user/private-registries/#use-an-access-token
+./kind-gcr.sh
+# run ct from the root of the git repo to test any helm charts that have changed in your current branch, relevant to main
+ct lint-and-install --target-branch main
+```

--- a/charts/gnomad-legacy-redirects/.helmignore
+++ b/charts/gnomad-legacy-redirects/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/gnomad-legacy-redirects/Chart.yaml
+++ b/charts/gnomad-legacy-redirects/Chart.yaml
@@ -23,6 +23,12 @@ version: 0.0.1
 # It is recommended to use it with quotes.
 appVersion: "75636d6"
 
+sources:
+  - https://github.com/broadinstitute/gnomad-helm
+  - https://github.com/broadinstitute/gnomad-redirect
+
+home: "https://gnomad.broadinstitute.org"
+
 maintainers:
   - name: broadinstitute/gnomad-browser
     url: https://gnomad.broadinstitute.org

--- a/charts/gnomad-legacy-redirects/Chart.yaml
+++ b/charts/gnomad-legacy-redirects/Chart.yaml
@@ -21,4 +21,8 @@ version: 0.0.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0200252"
+appVersion: "75636d6"
+
+maintainers:
+  - name: broadinstitute/gnomad-browser
+    url: https://gnomad.broadinstitute.org

--- a/charts/gnomad-legacy-redirects/Chart.yaml
+++ b/charts/gnomad-legacy-redirects/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gnomad-legacy-redirects
+description: A Helm chart for deploying the gnomad legacy-redirects service
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0200252"

--- a/charts/gnomad-legacy-redirects/README.md
+++ b/charts/gnomad-legacy-redirects/README.md
@@ -1,0 +1,55 @@
+# gnomad-legacy-redirects
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 75636d6](https://img.shields.io/badge/AppVersion-75636d6-informational?style=flat-square)
+
+A Helm chart for deploying the gnomad legacy-redirects service
+
+**Homepage:** <https://gnomad.broadinstitute.org>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| broadinstitute/gnomad-browser |  | <https://gnomad.broadinstitute.org> |
+
+## Source Code
+
+* <https://github.com/broadinstitute/gnomad-helm>
+* <https://github.com/broadinstitute/gnomad-redirect>
+
+## Installation
+
+1. `helm repo add gnomad broadinstitute.github.io/gnomad-helm`
+2. `helm install --set 'ingress.managed_cert=true' --set 'gcp_global_ip=1.2.3.4' gnomad-legacy-redirects gnomad/gnomad-legacy-redirects`
+
+## Customization
+
+The deployment can be customized by overriding the defaults in values.yaml using any of the methods described in the [`helm install` docs](https://helm.sh/docs/helm/helm_install/)
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| gcp_global_ip | string | `"0.0.0.0"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"gcr.io/exac-gnomad/legacy-redirects"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.enabled | bool | `true` |  |
+| ingress.host | string | `"exac.broadinstitute.org"` |  |
+| ingress.managed_cert | bool | `false` |  |
+| ingress.paths[0].path | string | `"/*"` |  |
+| ingress.paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources.limits.cpu | string | `"100m"` |  |
+| resources.limits.memory | string | `"32Mi"` |  |
+| resources.requests.cpu | string | `"10m"` |  |
+| resources.requests.memory | string | `"32Mi"` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"ClusterIP"` |  |
+| tolerations | list | `[]` |  |

--- a/charts/gnomad-legacy-redirects/README.md.gotmpl
+++ b/charts/gnomad-legacy-redirects/README.md.gotmpl
@@ -1,0 +1,25 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installation
+
+1. `helm repo add gnomad broadinstitute.github.io/gnomad-helm`
+2. `helm install --set 'ingress.managed_cert=true' --set 'gcp_global_ip=1.2.3.4' gnomad-legacy-redirects gnomad/gnomad-legacy-redirects`
+
+## Customization
+
+The deployment can be customized by overriding the defaults in values.yaml using any of the methods described in the [`helm install` docs](https://helm.sh/docs/helm/helm_install/)
+
+{{ template "chart.valuesSection" . }}

--- a/charts/gnomad-legacy-redirects/templates/NOTES.txt
+++ b/charts/gnomad-legacy-redirects/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "gnomad-legacy-redirects.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "gnomad-legacy-redirects.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "gnomad-legacy-redirects.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "gnomad-legacy-redirects.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/gnomad-legacy-redirects/templates/NOTES.txt
+++ b/charts/gnomad-legacy-redirects/templates/NOTES.txt
@@ -1,22 +1,10 @@
-1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
+The legacy redirects service is deployed at:
+  https://{{ .Values.ingress.host }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "gnomad-legacy-redirects.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "gnomad-legacy-redirects.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "gnomad-legacy-redirects.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "gnomad-legacy-redirects.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
+
+The helm release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}

--- a/charts/gnomad-legacy-redirects/templates/_helpers.tpl
+++ b/charts/gnomad-legacy-redirects/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gnomad-legacy-redirects.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gnomad-legacy-redirects.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gnomad-legacy-redirects.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gnomad-legacy-redirects.labels" -}}
+helm.sh/chart: {{ include "gnomad-legacy-redirects.chart" . }}
+{{ include "gnomad-legacy-redirects.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gnomad-legacy-redirects.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gnomad-legacy-redirects.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/gnomad-legacy-redirects/templates/configmap.yaml
+++ b/charts/gnomad-legacy-redirects/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gnomad-legacy-redirects.fullname" . }}
+data:
+  # property-like keys; each key maps to a simple value
+  ip: {{ .Values.gcp_global_ip }}

--- a/charts/gnomad-legacy-redirects/templates/configmap.yaml
+++ b/charts/gnomad-legacy-redirects/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "gnomad-legacy-redirects.labels" . | nindent 4 }}
 data:
   # property-like keys; each key maps to a simple value
-  ip: {{ .Values.gcp_global_ip }}
+  ip: {{ .Values.gcp_global_ip.address }}

--- a/charts/gnomad-legacy-redirects/templates/configmap.yaml
+++ b/charts/gnomad-legacy-redirects/templates/configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "gnomad-legacy-redirects.fullname" . }}
+  labels:
+    {{- include "gnomad-legacy-redirects.labels" . | nindent 4 }}
 data:
   # property-like keys; each key maps to a simple value
   ip: {{ .Values.gcp_global_ip }}

--- a/charts/gnomad-legacy-redirects/templates/deployment.yaml
+++ b/charts/gnomad-legacy-redirects/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gnomad-legacy-redirects.fullname" . }}
+  labels:
+    {{- include "gnomad-legacy-redirects.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gnomad-legacy-redirects.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "gnomad-legacy-redirects.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            intialDelaySeconds: 5
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/gnomad-legacy-redirects/templates/deployment.yaml
+++ b/charts/gnomad-legacy-redirects/templates/deployment.yaml
@@ -18,10 +18,6 @@ spec:
       labels:
         {{- include "gnomad-legacy-redirects.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/gnomad-legacy-redirects/templates/deployment.yaml
+++ b/charts/gnomad-legacy-redirects/templates/deployment.yaml
@@ -26,14 +26,16 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: INGRESS_IP
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "gnomad-legacy-redirects.fullname" . }}
+                  key: ip
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
           readinessProbe:
             httpGet:
               path: /health/ready

--- a/charts/gnomad-legacy-redirects/templates/deployment.yaml
+++ b/charts/gnomad-legacy-redirects/templates/deployment.yaml
@@ -40,9 +40,11 @@ spec:
             periodSeconds: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{ if eq .Values.integration_test false }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:

--- a/charts/gnomad-legacy-redirects/templates/deployment.yaml
+++ b/charts/gnomad-legacy-redirects/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             httpGet:
               path: /health/ready
               port: http
-            intialDelaySeconds: 5
+            initialDelaySeconds: 5
             periodSeconds: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "gnomad-legacy-redirects.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -25,41 +14,19 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range .Values.ingress.paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
-    {{- end }}
 ---
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
@@ -75,7 +42,5 @@ metadata:
   name: {{ include "gnomad-legacy-redirects.fullname" . }}
 spec:
   domains:
-    {{- range .Values.ingress.hosts }}
-    - {{ .host | quote }}
-    {{- end }}
+    - {{ .Values.ingress.host | quote}}
 {{- end }}

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -8,8 +8,10 @@ metadata:
   labels:
     {{- include "gnomad-legacy-redirects.labels" . | nindent 4 }}
   annotations:
-    ingress.gcp.kubernetes.io/managed-certificates: {{ include "gnomad-legacy-redirects.fullname" . }}
-    networking.gke.io/v1beta1.FrontendConfig: {{ include "gnomad-legacy-redirects.fullname" . }}
+  {{- if .Values.ingress.managed_cert }}
+    ingress.gcp.kubernetes.io/managed-certificates: {{ $fullName }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ $fullName }}
+  {{- end }}
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -27,11 +29,12 @@ spec:
                 port:
                   number: {{ $svcPort }}
           {{- end }}
+{{- if .Values.ingress.managed_cert }}
 ---
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
-  name: {{ include "gnomad-legacy-redirects.fullname" . }}
+  name: {{ $fullName }}
 spec:
   redirectToHttps:
     enabled: true
@@ -39,8 +42,9 @@ spec:
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
-  name: {{ include "gnomad-legacy-redirects.fullname" . }}
+  name: {{ $fullName }}
 spec:
   domains:
     - {{ .Values.ingress.host | quote}}
+{{- end }}
 {{- end }}

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ .Values.service.port }}
+                  number: {{ $.Values.service.port }}
           {{- end }}
 {{- if .Values.ingress.managed_cert }}
 ---

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ $.Values.service.port }}
+                  number: {{ .Values.service.port }}
 {{- if eq .Values.integration_test false }}
 ---
 apiVersion: networking.gke.io/v1beta1

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "gnomad-legacy-redirects.labels" . | nindent 4 }}
   annotations:
-  {{- if .Values.ingress.managed_cert }}
+  {{- if eq .Values.integration_test false }}
     ingress.gcp.kubernetes.io/managed-certificates: {{ $fullName }}
     networking.gke.io/v1beta1.FrontendConfig: {{ $fullName }}
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.gcp_global_ip.name }}
@@ -29,7 +29,7 @@ spec:
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}
-{{- if .Values.ingress.managed_cert }}
+{{- if eq .Values.integration_test false }}
 ---
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -20,15 +20,13 @@ spec:
     - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-          {{- range .Values.ingress.paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $.Values.service.port }}
-          {{- end }}
 {{- if eq .Values.integration_test false }}
 ---
 apiVersion: networking.gke.io/v1beta1

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "gnomad-legacy-redirects.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "gnomad-legacy-redirects.labels" . | nindent 4 }}
+  annotations:
+    ingress.gcp.kubernetes.io/managed-certificates: {{ include "gnomad-legacy-redirects.fullname" . }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "gnomad-legacy-redirects.fullname" . }}
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+---
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ include "gnomad-legacy-redirects.fullname" . }}
+spec:
+  redirectToHttps:
+    enabled: true
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ include "gnomad-legacy-redirects.fullname" . }}
+spec:
+  domains:
+    {{- range .Values.ingress.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -17,11 +17,11 @@ metadata:
   {{- end }}
 spec:
   rules:
-    - host: {{ .Values.ingress.host | quote }}
+    - host: "exac.broadinstitute.org"
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
-            pathType: {{ .Values.ingress.pathType }}
+          - path: /*
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/gnomad-legacy-redirects/templates/ingress.yaml
+++ b/charts/gnomad-legacy-redirects/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "gnomad-legacy-redirects.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -11,6 +10,7 @@ metadata:
   {{- if .Values.ingress.managed_cert }}
     ingress.gcp.kubernetes.io/managed-certificates: {{ $fullName }}
     networking.gke.io/v1beta1.FrontendConfig: {{ $fullName }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.gcp_global_ip.name }}
   {{- end }}
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -27,7 +27,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ $svcPort }}
+                  number: {{ .Values.service.port }}
           {{- end }}
 {{- if .Values.ingress.managed_cert }}
 ---
@@ -45,6 +45,6 @@ metadata:
   name: {{ $fullName }}
 spec:
   domains:
-    - {{ .Values.ingress.host | quote}}
+    - {{ .Values.ingress.host | quote }}
 {{- end }}
 {{- end }}

--- a/charts/gnomad-legacy-redirects/templates/service.yaml
+++ b/charts/gnomad-legacy-redirects/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gnomad-legacy-redirects.fullname" . }}
+  labels:
+    {{- include "gnomad-legacy-redirects.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gnomad-legacy-redirects.selectorLabels" . | nindent 4 }}

--- a/charts/gnomad-legacy-redirects/templates/tests/test-connection.yaml
+++ b/charts/gnomad-legacy-redirects/templates/tests/test-connection.yaml
@@ -8,8 +8,8 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "gnomad-legacy-redirects.fullname" . }}:{{ .Values.service.port }}']
+    - name: curl
+      image: curlimages/curl:latest
+      command: ['curl']
+      args: ['--header', 'Host: exac.broadinstitute.org', '--fail-with-body', '{{ include "gnomad-legacy-redirects.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/gnomad-legacy-redirects/templates/tests/test-connection.yaml
+++ b/charts/gnomad-legacy-redirects/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "gnomad-legacy-redirects.fullname" . }}-test-connection"
+  labels:
+    {{- include "gnomad-legacy-redirects.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "gnomad-legacy-redirects.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/gnomad-legacy-redirects/values.yaml
+++ b/charts/gnomad-legacy-redirects/values.yaml
@@ -2,7 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+nameOverride: ""
+fullnameOverride: ""
+
 replicaCount: 1
+
+imagePullSecrets: []
+
+podAnnotations: {}
 
 image:
   repository: gcr.io/exac-gnomad/legacy-redirects
@@ -10,17 +17,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
-
-podAnnotations: {}
-
 service:
   type: ClusterIP
   port: 80
 
-gcp_global_ip: "0.0.0.0"
+gcp_global_ip:
+  address: "34.36.116.121"
+  name: prod-legacy-redirects-ip
 
 ingress:
   enabled: true
@@ -43,6 +46,6 @@ nodeSelector:
   {}
   # cloud.google.com/gke-nodepool: main-pool
 
-tolerations: []
-
 affinity: {}
+
+tolerations: []

--- a/charts/gnomad-legacy-redirects/values.yaml
+++ b/charts/gnomad-legacy-redirects/values.yaml
@@ -25,6 +25,8 @@ gcp_global_ip: "0.0.0.0"
 ingress:
   enabled: true
   host: exac.broadinstitute.org
+  # managed_cert defaults to false to ease testing. Set to true for prod deployments
+  managed_cert: false
   paths:
     - path: /*
       pathType: ImplementationSpecific

--- a/charts/gnomad-legacy-redirects/values.yaml
+++ b/charts/gnomad-legacy-redirects/values.yaml
@@ -28,8 +28,6 @@ gcp_global_ip:
 ingress:
   enabled: true
   host: exac.broadinstitute.org
-  # managed_cert defaults to false to ease testing. Set to true for prod deployments
-  managed_cert: false
   paths:
     - path: /*
       pathType: ImplementationSpecific

--- a/charts/gnomad-legacy-redirects/values.yaml
+++ b/charts/gnomad-legacy-redirects/values.yaml
@@ -7,8 +7,6 @@ fullnameOverride: ""
 
 replicaCount: 1
 
-imagePullSecrets: []
-
 podAnnotations: {}
 
 image:
@@ -28,9 +26,8 @@ gcp_global_ip:
 ingress:
   enabled: true
   host: exac.broadinstitute.org
-  paths:
-    - path: /*
-      pathType: ImplementationSpecific
+  path: /*
+  pathType: ImplementationSpecific
 
 resources:
   requests:

--- a/charts/gnomad-legacy-redirects/values.yaml
+++ b/charts/gnomad-legacy-redirects/values.yaml
@@ -23,23 +23,11 @@ service:
 gcp_global_ip: "0.0.0.0"
 
 ingress:
-  enabled: false
-
-# Example ingress
-# ingress:
-#   enabled: true
-#   className: ""
-#   annotations:
-#     kubernetes.io/ingress.global-static-ip-name: prod-legacy-redirects-ip
-#   hosts:
-#     - host: exac.broadinstitute.org
-#       paths:
-#         - path: /
-#           pathType: ImplementationSpecific
-#   tls: []
-#  - secretName: chart-example-tls
-#    hosts:
-#      - chart-example.local
+  enabled: true
+  host: exac.broadinstitute.org
+  paths:
+    - path: /*
+      pathType: ImplementationSpecific
 
 resources:
   requests:

--- a/charts/gnomad-legacy-redirects/values.yaml
+++ b/charts/gnomad-legacy-redirects/values.yaml
@@ -20,20 +20,26 @@ service:
   type: ClusterIP
   port: 80
 
+gcp_global_ip: "0.0.0.0"
+
 ingress:
-  enabled: true
-  className: ""
-  annotations:
-    kubernetes.io/ingress.global-static-ip-name: prod-legacy-redirects-ip
-  hosts:
-    - host: exac.broadinstitute.org
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+  enabled: false
+
+# Example ingress
+# ingress:
+#   enabled: true
+#   className: ""
+#   annotations:
+#     kubernetes.io/ingress.global-static-ip-name: prod-legacy-redirects-ip
+#   hosts:
+#     - host: exac.broadinstitute.org
+#       paths:
+#         - path: /
+#           pathType: ImplementationSpecific
+#   tls: []
+#  - secretName: chart-example-tls
+#    hosts:
+#      - chart-example.local
 
 resources:
   requests:
@@ -44,7 +50,8 @@ resources:
     memory: 32Mi
 
 nodeSelector:
-  cloud.google.com/gke-nodepool: main-pool
+  {}
+  # cloud.google.com/gke-nodepool: main-pool
 
 tolerations: []
 

--- a/charts/gnomad-legacy-redirects/values.yaml
+++ b/charts/gnomad-legacy-redirects/values.yaml
@@ -25,9 +25,6 @@ gcp_global_ip:
 
 ingress:
   enabled: true
-  host: exac.broadinstitute.org
-  path: /*
-  pathType: ImplementationSpecific
 
 resources:
   requests:
@@ -38,8 +35,7 @@ resources:
     memory: 32Mi
 
 nodeSelector:
-  {}
-  # cloud.google.com/gke-nodepool: main-pool
+  cloud.google.com/gke-nodepool: main-pool
 
 affinity: {}
 

--- a/charts/gnomad-legacy-redirects/values.yaml
+++ b/charts/gnomad-legacy-redirects/values.yaml
@@ -1,0 +1,51 @@
+# Default values for gnomad-legacy-redirects.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: gcr.io/exac-gnomad/legacy-redirects
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: prod-legacy-redirects-ip
+  hosts:
+    - host: exac.broadinstitute.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 32Mi
+
+nodeSelector:
+  cloud.google.com/gke-nodepool: main-pool
+
+tolerations: []
+
+affinity: {}

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,2 @@
+target-branch: main
+helm-extra-set-args: --set=integration_test=true


### PR DESCRIPTION
This defines a chart to provide a templated and flexible deployment for https://github.com/broadinstitute/gnomad-redirect

Also included is a chart-releaser action which will create a helm repository for this git repo, and publish any updated charts in the `charts/` folder to it.