### PR TITLE
add a gnomad-blog chart

### DIFF
--- a/charts/gnomad-blog/.helmignore
+++ b/charts/gnomad-blog/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/gnomad-blog/Chart.yaml
+++ b/charts/gnomad-blog/Chart.yaml
@@ -22,3 +22,13 @@ version: 0.0.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "bff889b8"
+
+sources:
+  - https://github.com/broadinstitute/gnomad-helm
+  - https://github.com/broadinstitute/gnomad-blog
+
+home: "https://gnomad.broadinstitute.org"
+
+maintainers:
+  - name: broadinstitute/gnomad-browser
+    url: https://gnomad.broadinstitute.org

--- a/charts/gnomad-blog/Chart.yaml
+++ b/charts/gnomad-blog/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gnomad-blog
+description: A Helm chart for deploying the gnomad-blog
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "bff889b8"

--- a/charts/gnomad-blog/README.md
+++ b/charts/gnomad-blog/README.md
@@ -1,0 +1,44 @@
+# gnomad-blog
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: bff889b8](https://img.shields.io/badge/AppVersion-bff889b8-informational?style=flat-square)
+
+A Helm chart for deploying the gnomad-blog
+
+**Homepage:** <https://gnomad.broadinstitute.org>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| broadinstitute/gnomad-browser |  | <https://gnomad.broadinstitute.org> |
+
+## Source Code
+
+* <https://github.com/broadinstitute/gnomad-helm>
+* <https://github.com/broadinstitute/gnomad-blog>
+
+## Installation
+
+1. `helm repo add gnomad broadinstitute.github.io/gnomad-helm`
+2. `helm install --set 'proxy_ips="1.2.3.4,0.0.0.0"' gnomad-blog gnomad/gnomad-blog`
+
+## Customization
+
+The deployment can be customized by overriding the defaults in values.yaml using any of the methods described in the [`helm install` docs](https://helm.sh/docs/helm/helm_install/)
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| fullnameOverride | string | `""` |  |
+| gcp_blog_oauth_secrets_name | string | `"blog-oauth-secrets"` |  |
+| images.authImage.tag | string | `""` |  |
+| images.webImage.tag | string | `""` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| proxy_ips | string | `"127.0.0.1,0.0.0.0"` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| secrets_cluster_secretstore_name | string | `"gcpsm"` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"ClusterIP"` |  |

--- a/charts/gnomad-blog/README.md
+++ b/charts/gnomad-blog/README.md
@@ -17,6 +17,16 @@ A Helm chart for deploying the gnomad-blog
 * <https://github.com/broadinstitute/gnomad-helm>
 * <https://github.com/broadinstitute/gnomad-blog>
 
+## Requirements
+
+This chart uses an ExternalSecret manifest to sync secrets from the GCP secret manager to our kubernetes cluster. You must define a GCP secret with a JSON document containing k/v pairs for the blog OAuth client and secret IDs, and then grant your GKE cluster's service account roles/secretmanager.secretAccessor permissions on that secret. The name of the GCP secret can then be passed into the chart with the `gcp_blog_oauth_secrets_name` variable.
+
+Example GCP secret value:
+
+```json
+{"client-id": "abc123", "client-secret": "def345"}
+```
+
 ## Installation
 
 1. `helm repo add gnomad broadinstitute.github.io/gnomad-helm`

--- a/charts/gnomad-blog/README.md.gotmpl
+++ b/charts/gnomad-blog/README.md.gotmpl
@@ -1,0 +1,25 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installation
+
+1. `helm repo add gnomad broadinstitute.github.io/gnomad-helm`
+2. `helm install --set 'proxy_ips="1.2.3.4,0.0.0.0"' gnomad-blog gnomad/gnomad-blog`
+
+## Customization
+
+The deployment can be customized by overriding the defaults in values.yaml using any of the methods described in the [`helm install` docs](https://helm.sh/docs/helm/helm_install/)
+
+{{ template "chart.valuesSection" . }}

--- a/charts/gnomad-blog/README.md.gotmpl
+++ b/charts/gnomad-blog/README.md.gotmpl
@@ -13,6 +13,16 @@
 
 {{ template "chart.requirementsSection" . }}
 
+## Requirements
+
+This chart uses an ExternalSecret manifest to sync secrets from the GCP secret manager to our kubernetes cluster. You must define a GCP secret with a JSON document containing k/v pairs for the blog OAuth client and secret IDs, and then grant your GKE cluster's service account roles/secretmanager.secretAccessor permissions on that secret. The name of the GCP secret can then be passed into the chart with the `gcp_blog_oauth_secrets_name` variable.
+
+Example GCP secret value:
+
+```json
+{"client-id": "abc123", "client-secret": "def345"}
+```
+
 ## Installation
 
 1. `helm repo add gnomad broadinstitute.github.io/gnomad-helm`

--- a/charts/gnomad-blog/templates/_helpers.tpl
+++ b/charts/gnomad-blog/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gnomad-blog.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gnomad-blog.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gnomad-blog.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gnomad-blog.labels" -}}
+helm.sh/chart: {{ include "gnomad-blog.chart" . }}
+{{ include "gnomad-blog.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gnomad-blog.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gnomad-blog.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+component: {{ include "gnomad-blog.chart" . }}
+{{- end }}

--- a/charts/gnomad-blog/templates/configmap.yaml
+++ b/charts/gnomad-blog/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gnomad-blog.fullname" . }}
+  labels:
+    {{- include "gnomad-blog.labels" . | nindent 4 }}
+data:
+  # property-like keys; each key maps to a simple value
+  ips: {{ .Values.proxy_ips }}

--- a/charts/gnomad-blog/templates/deployment.yaml
+++ b/charts/gnomad-blog/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gnomad-blog.fullname" . }}
+  labels:
+    {{- include "gnomad-blog.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gnomad-blog.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gnomad-blog.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: web
+          image: "gcr.io/exac-gnomad/gnomad-blog:{{ .Values.images.webImage.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PROXY_IPS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "gnomad-blog.fullname" . }}
+                  key: ips
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+        {{- if eq .Values.integration_test false }}
+        - name: auth
+          image: "gcr.io/exac-gnomad/gnomad-blog-auth:{{ .Values.images.authImage.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gnomad-blog.fullname" . }}-oauth-secrets
+                  key: client-id
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gnomad-blog.fullname" . }}-oauth-secrets
+                  key: client-secret
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/gnomad-blog/templates/secret.yaml
+++ b/charts/gnomad-blog/templates/secret.yaml
@@ -1,0 +1,20 @@
+{{- if eq .Values.integration_test false -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "gnomad-blog.fullname" . }}
+  labels:
+    {{- include "gnomad-blog.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.secrets_cluster_secretstore_name }}
+  target:
+    name: {{ include "gnomad-blog.fullname" . }}-oauth-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+  - extract:
+      key: {{ .Values.gcp_blog_oauth_secrets_name }}
+{{- end }}

--- a/charts/gnomad-blog/templates/service.yaml
+++ b/charts/gnomad-blog/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gnomad-blog.fullname" . }}
+  labels:
+    {{- include "gnomad-blog.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gnomad-blog.selectorLabels" . | nindent 4 }}

--- a/charts/gnomad-blog/templates/tests/test-connection.yaml
+++ b/charts/gnomad-blog/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: curl
-      image: curlimages:latest
+      image: curlimages/curl:latest
       command: ['curl']
-      args: ['{{ include "gnomad-blog.fullname" . }}:{{ .Values.service.port }}']
+      args: ['-L', '--fail-with-body', '{{ include "gnomad-blog.fullname" . }}:{{ .Values.service.port }}/news']
   restartPolicy: Never

--- a/charts/gnomad-blog/templates/tests/test-connection.yaml
+++ b/charts/gnomad-blog/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "gnomad-blog.fullname" . }}-test-connection"
+  labels:
+    {{- include "gnomad-blog.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: curl
+      image: curlimages:latest
+      command: ['curl']
+      args: ['{{ include "gnomad-blog.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/gnomad-blog/values.yaml
+++ b/charts/gnomad-blog/values.yaml
@@ -35,3 +35,4 @@ nodeSelector: {}
 
 secrets_cluster_secretstore_name: gcpsm
 gcp_blog_oauth_secrets_name: blog-oauth-secrets
+proxy_ips: "127.0.0.1,0.0.0.0"

--- a/charts/gnomad-blog/values.yaml
+++ b/charts/gnomad-blog/values.yaml
@@ -1,0 +1,37 @@
+# Default values for gnomad-blog.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+images:
+  webImage:
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  authImage:
+    tag: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+secrets_cluster_secretstore_name: gcpsm
+gcp_blog_oauth_secrets_name: blog-oauth-secrets


### PR DESCRIPTION
rebased off of legacy-redir to use the lint/test config for now. Will rebase off of main after that merges.